### PR TITLE
Added protractor as dependency so astrolabe can be run outside of the protractor CLI

### DIFF
--- a/lib/astrolabe/base.js
+++ b/lib/astrolabe/base.js
@@ -1,3 +1,7 @@
+if ( typeof protractor === 'undefined' ) {
+    protractor = require('protractor');
+}
+
 function typeOf(name, obj) {
     return Object.prototype.toString.call(obj) === '[object ' + name + ']';
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "url": "http://github.com/stuplum/astrolabe/issues"
   },
   "dependencies": {
-    "underscore": "*"
+    "underscore": "*",
+    "protractor": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
I have a scenario where I want to run astrolabe through my node.js test script and it was throwing an error because protractor was undefined. This was due to the assumption that astrolabe would be run using the protractor CLI.
