### PR TITLE
fix(api): Selector strategies must have context.

### DIFF
--- a/lib/astrolabe/base.js
+++ b/lib/astrolabe/base.js
@@ -45,8 +45,6 @@ Base.prototype = Object.create({}, {
     exception:    { value: function(name) { return new exceptions.Exception(name); } },
     findElement:  { value: function(by) { return this.context.findElement(by); } },
     findElements: { value: function(by) { return this.context.findElements(by); } },
-    findBy: { value: function(byType, selector) { return this.findElement(byType(selector)); } },
-    findAllBy: { value: function(byType, selector) { return this.findElements(byType(selector)); } },
     find: {
         get: function() {
             var base = this;
@@ -72,9 +70,10 @@ Base.prototype = Object.create({}, {
             var bys = {};
             var allBys = {};
             selectorStrategies.forEach(function (strategy) {
-                bys[strategy] = function (selector) { return base.findBy(base.by[selector], selector); };
+                var by = base.by[strategy];
+                bys[strategy] = function (selector) { return base.findElement(by(selector)); };
                 allBys[strategy] = function (selector) {
-                    return base.findAllBy(base.by[selector], selector);
+                    return base.findElements(by(selector));
                 };
             });
 


### PR DESCRIPTION
At some point I said I was going to incorporate the new api into my
Astrolabe tutorial, and I did today. I was upset to find that these
new functions don't work. Fortunately it was a simple fix.

I can now attest that these functions are working in a real life app.

This definitely raises the concern that without end to end tests,
new changes like this aren't going to be tested until they're put
into a real application. Expect a pull request for some kind of an
"example app" directory, complete with end to end tests for each
kind of element and selector.
