### PR TITLE
refact(protractor): Remove getInstance usage

### DIFF
--- a/lib/astrolabe/base.js
+++ b/lib/astrolabe/base.js
@@ -41,7 +41,7 @@ Base.extend = extend;
 
 Base.prototype = Object.create({}, {
     by:           { value: protractor.By },
-    driver:       { get: function() { return protractor.getInstance(); } },
+    driver:       { get: function() { return browser; } },
     exception:    { value: function(name) { return new exceptions.Exception(name); } },
     findElement:  { value: function(by) { return this.context.findElement(by); } },
     findElements: { value: function(by) { return this.context.findElements(by); } },

--- a/test/base.js
+++ b/test/base.js
@@ -5,12 +5,12 @@ describe('Base', function() {
     beforeEach(function() {
 
         this.mockProtractor = {
-            By: 'protractor "By" property',
-            getInstance: sinon.stub()
+            By: 'protractor "By" property'
         };
 
         Base = Sandbox.require('../lib/astrolabe/base', {
-            globals: { protractor: this.mockProtractor }
+            globals: { protractor: this.mockProtractor,
+                       browser: 'driver instance' }
         });
 
         this.base = new Base();
@@ -21,9 +21,6 @@ describe('Base', function() {
     });
 
     it('should have a driver instance', function() {
-
-        this.mockProtractor.getInstance.returns('driver instance');
-
         this.base.driver.should.be.string('driver instance');
     });
 

--- a/test/module.js
+++ b/test/module.js
@@ -11,8 +11,9 @@ describe('Module', function() {
 
         global.protractor = {
             By: 'protractor "By" property',
-            getInstance: function() { return mockDriver; }
         };
+
+        global.browser = mockDriver;
 
         var Module = require('../lib/astrolabe/module');
 

--- a/test/page.js
+++ b/test/page.js
@@ -10,7 +10,8 @@ describe('Page', function() {
             findElements: sinon.stub(),
             getCurrentUrl: sinon.stub(),
             addMockModule: sinon.stub(),
-            clearMockModules: sinon.stub()
+            clearMockModules: sinon.stub(),
+            browser: sinon.stub()
         };
 
         global.protractor = {
@@ -33,9 +34,10 @@ describe('Page', function() {
                 repeater: sinon.stub(),
                 buttonText: sinon.stub(),
                 partialButtonText: sinon.stub()
-            },
-            getInstance: function() { return mockDriver; }
+            }
         };
+
+        global.browser = mockDriver;
 
         var mockSerializer = {
             serialize: sinon.stub().returns("serialized script")


### PR DESCRIPTION
Astrolabe doesn't work with Protractor v1.5.0 unless `getInstance` is removed from the codebase.
