### PR TITLE
Return Promise from Page.go

### DIFF
--- a/lib/astrolabe/page.js
+++ b/lib/astrolabe/page.js
@@ -12,7 +12,7 @@ var go = function() {
         if(underscore.isObject(arg)) { url.addParams(arg); }
     });
 
-    this.context.get(url.url);
+    return this.context.get(url.url);
 };
 
 var mockBackend = function(script) {


### PR DESCRIPTION
The method it wraps, browser.get, returns a Promise (though undocumented).

Fixes #26
