### PR TITLE
Lock devDependencies to today's latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
         "exceptions": "~0.1.1"
     },
     "devDependencies": {
-        "mocha": "*",
-        "chai": "*",
-        "sinon": "~1.7.3",
-        "sinon-chai": "~2.4.0",
+        "mocha": "2.1.0",
+        "chai": "2.1.0",
+        "sinon": "1.7.3",
+        "sinon-chai": "2.7.0",
         "sandboxed-module": "0.2.1"
     }
 }


### PR DESCRIPTION
Mixing version restrictions is a bad idea when libraries depend on one another. Probably easiest to just lock them into working set for now.

Fixes #28
